### PR TITLE
[feature] Adding missing properties to subnet and virtualNetworkPeering objects

### DIFF
--- a/Docs/Resources/Network/VirtualNetwork.md
+++ b/Docs/Resources/Network/VirtualNetwork.md
@@ -77,11 +77,25 @@
   - Type: networkSecurityGroup
 - `routeTable`: (Optional) A `routeTable` object.
   - Type: routeTable
-  
+- `privateEndpointNetworkPolicies`: (Optional) Enable or Disable apply network policies on private endpoint in the subnet.
+  - Type: string
+  - Valid values: `Enabled` or `Disabled`
+- `privateLinkServiceNetworkPolicies`: (Optional) Enable or Disable apply network policies on private link service in the subnet.
+  - Type: string
+  - Valid Values: `Enabled` or `Disabled`
+
 ### virtualNetworkPeering object
 
 - `name`: (Required) The virtual network peering name.
   - Type: string
+- `allowVirtualNetworkAccess`: (Optional) Whether the VMs in the local virtual network space would be able to access the VMs in remote virtual network space.
+  - Type: boolean
+- `allowForwardedTraffic`: (Optional) Whether the forwarded traffic from the VMs in the local virtual network will be allowed/disallowed in remote virtual network.
+  - Type: boolean
+- `allowGatewayTransit`: (Optional) If gateway links can be used in remote virtual networking to link to this virtual network.
+  - Type: boolean
+- `useRemoteGateways`: (Optional) If remote gateways can be used on this virtual network.
+  - Type: boolean
 - `remoteVirtualNetwork`: (Required) A `remoteVirtualNetwork` object.
   - Type: remoteVirtualNetwork
 

--- a/Samples/VirtualNetwork/definition.json
+++ b/Samples/VirtualNetwork/definition.json
@@ -124,6 +124,8 @@
                         {
                             "name": "{parameters.spokeNetwork.subnetName}",
                             "addressPrefix": "{parameters.spokeNetwork.subnetPrefix}",
+                            "privateEndpointNetworkPolicies": "Enabled",
+                            "privateLinkServiceNetworkPolicies": "Enabled",
                             "networkSecurityGroup": {
                                 "name": "{parameters.spokeNetwork.subnetNsgName}"
                             },
@@ -135,6 +137,10 @@
                     "virtualNetworkPeerings": [
                         {
                             "name": "spoke-one-to-hub",
+                            "allowVirtualNetworkAccess": true,
+                            "allowForwardedTraffic": false,
+                            "allowGatewayTransit": false,
+                            "useRemoteGateways": false,
                             "remoteVirtualNetwork": {
                                 "name": "{parameters.hubNetwork.name}"
                             }

--- a/Source/Resources/Network/VirtualNetwork/Parsers/Definition.psm1
+++ b/Source/Resources/Network/VirtualNetwork/Parsers/Definition.psm1
@@ -11,10 +11,10 @@ function Find-VirtualNetworks {
         $properties = @()
 
         if ($virtualNetwork.location) {
-            $properties += @{propertyName = 'location'; propertyValue = $virtualNetwork.location; displayValue = $virtualNetwork.location }
+            $properties += Add-Property -PropertyName 'location' -PropertyValue $virtualNetwork.location
         }
         if ($null -ne $virtualNetwork.enableDdosProtection) {
-            $properties += @{propertyName = 'enableDdosProtection'; propertyValue = $virtualNetwork.enableDdosProtection; displayValue = $virtualNetwork.enableDdosProtection }
+            $properties += Add-Property -PropertyName 'enableDdosProtection' -PropertyValue $virtualNetwork.enableDdosProtection
         }
 
         if ($virtualNetwork.subnets) {
@@ -22,16 +22,43 @@ function Find-VirtualNetworks {
                 $subnetProperties = @()
 
                 if ($subnet.addressPrefix) {
-                    $subnetProperties += @{propertyName = 'addressPrefix'; propertyValue = $subnet.addressPrefix; displayValue = $subnet.addressPrefix }
+                    $subnetProperties += Add-Property -PropertyName 'addressPrefix' -PropertyValue $subnet.addressPrefix
+                }
+                if ($subnet.privateEndpointNetworkPolicies) {
+                    $subnetProperties += Add-Property -PropertyName 'privateEndpointNetworkPolicies' -PropertyValue $subnet.privateEndpointNetworkPolicies
+                }
+                if ($subnet.privateLinkServiceNetworkPolicies) {
+                    $subnetProperties += Add-Property -PropertyName 'privateLinkServiceNetworkPolicies' -PropertyValue $subnet.privateLinkServiceNetworkPolicies
                 }
                 if ($subnet.networkSecurityGroup) {
-                    $subnetProperties += @{propertyName = 'networkSecurityGroup'; propertyValue = $subnet.networkSecurityGroup; displayValue = $subnet.networkSecurityGroup.name }
+                    $subnetProperties += Add-Property -PropertyName 'networkSecurityGroup' -PropertyValue $subnet.networkSecurityGroup -DisplayValue $subnet.networkSecurityGroup.name 
                 }
                 if ($subnet.routeTable) {
-                    $subnetProperties += @{propertyName = 'routeTable'; propertyValue = $subnet.routeTable; displayValue = $subnet.routeTable.name }
+                    $subnetProperties += Add-Property -PropertyName 'routeTable' -PropertyValue $subnet.routeTable -DisplayValue $subnet.routeTable.name
                 }
 
                 $subnet.properties = $subnetProperties
+            }
+        }
+
+        if ($virtualNetwork.virtualNetworkPeerings) {
+            foreach ($peering in $virtualNetwork.virtualNetworkPeerings) {
+                $peeringProperties = @()
+
+                if ($null -ne $peering.allowVirtualNetworkAccess) {
+                    $peeringProperties += Add-Property -PropertyName 'allowVirtualNetworkAccess' -PropertyValue $peering.allowVirtualNetworkAccess
+                }
+                if ($null -ne $peering.allowForwardedTraffic) {
+                    $peeringProperties += Add-Property -PropertyName 'allowForwardedTraffic' -PropertyValue $peering.allowForwardedTraffic
+                }
+                if ($null -ne $peering.allowGatewayTransit) {
+                    $peeringProperties += Add-Property -PropertyName 'allowGatewayTransit' -PropertyValue $peering.allowGatewayTransit
+                }
+                if ($null -ne $peering.useRemoteGateways) {
+                    $peeringProperties += Add-Property -PropertyName 'useRemoteGateways' -PropertyValue $peering.useRemoteGateways
+                }
+
+                $peering.properties = $peeringProperties
             }
         }
 
@@ -40,3 +67,24 @@ function Find-VirtualNetworks {
 
     return $virtualNetworks
 }
+
+function Add-Property {
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNull()]
+        [string] $PropertyName,
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNull()]
+        [PSObject] $PropertyValue,
+        [Parameter(Mandatory = $false)]
+        [PSObject] $DisplayValue
+    )
+
+    if (!$DisplayValue) {
+        $DisplayValue = $PropertyValue
+    }
+
+    return @{propertyName = $PropertyName; propertyValue = $PropertyValue; displayValue = $DisplayValue }
+}
+
+Export-ModuleMember -Function Find-VirtualNetworks

--- a/Source/Resources/Network/VirtualNetwork/VirtualNetwork.Tests.ps1
+++ b/Source/Resources/Network/VirtualNetwork/VirtualNetwork.Tests.ps1
@@ -24,10 +24,12 @@ Describe 'Virtual Network <name> Acceptance Tests' -ForEach $VirtualNetworks {
     Context 'Virtual Network <name>'{
         It 'Validate virtual network <name> has been provisioned' {
             $virtualNetwork | Should -Not -BeNullOrEmpty
-            $VirtualNetwork.ProvisioningState | Should -Be "Succeeded"
+            $virtualNetwork.ProvisioningState | Should -Be "Succeeded"
         }
-        It 'Validate virtual network <propertyName> is <displayValue>' -ForEach $properties {
-            $VirtualNetwork.$propertyName | Should -Be $propertyValue
+        It 'Validate virtual network <propertyName> is <propertyValue>' -ForEach $properties {
+            $propertyName | Should -Not -BeNullOrEmpty
+            $propertyValue | Should -Not -BeNullOrEmpty
+            $virtualNetwork.$propertyName | Should -Be $propertyValue
         }
         It 'Validate virtual network address space contains <addressPrefix>' -ForEach $addressSpace {
             $virtualNetwork.AddressSpace.AddressPrefixes | Should -Contain $addressPrefix
@@ -35,25 +37,12 @@ Describe 'Virtual Network <name> Acceptance Tests' -ForEach $VirtualNetworks {
         It 'Validate virtual network subnets contains <name> subnet' -ForEach $subnets {
             $virtualNetwork.Subnets.Name | Should -Contain $name
         }
-        It 'Validate virtual network peering with <remoteVirtualNetwork.name> is connected' -ForEach $virtualNetworkPeerings {
-            $peering = $virtualNetwork.VirtualNetworkPeerings | Where-Object { $_.Name -eq $name }
-            $remoteVirtualNetwork = Get-VirtualNetwork -Definition $Definition `
-                                                       -Contexts $Contexts `
-                                                       -Name $remoteVirtualNetwork.name `
-                                                       -SubscriptionId $remoteVirtualNetwork.subscriptionId `
-                                                       -ResourceGroupName $remoteVirtualNetwork.resourceGroupName 
-            
-            $peering | Should -Not -BeNullOrEmpty
-            $peering.RemoteVirtualNetwork.Id | Should -Be $remoteVirtualNetwork.Id
-            $peering.PeeringState | Should -Be "Connected"
-            $peering.ProvisioningState | Should -Be "Succeeded"
-        }
     }
 
     Context 'Subnet <name>' -ForEach $subnets {
         BeforeAll {
             [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '')]
-            $Subnet = $virtualNetwork.Subnets | Where-Object {$_.Name -eq $name}
+            $subnet = $virtualNetwork.Subnets | Where-Object {$_.Name -eq $name}
         }
 
         It 'Validate subnet <propertyName> is <displayValue>' -ForEach $properties {
@@ -78,8 +67,35 @@ Describe 'Virtual Network <name> Acceptance Tests' -ForEach $VirtualNetworks {
                 $Subnet.RouteTable.Id | Should -Be $routeTable.Id
             }
             else {
-                $Subnet.$propertyName | Should -Be $propertyValue
+                $propertyName | Should -Not -BeNullOrEmpty
+                $propertyValue | Should -Not -BeNullOrEmpty
+                $subnet.$propertyName | Should -Be $propertyValue
             }
+        }
+    }
+
+    Context 'Virtual Network Peering with <remoteVirtualNetwork.name>' -ForEach $virtualNetworkPeerings {
+        BeforeAll {
+            [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '')]
+            $peering = $virtualNetwork.VirtualNetworkPeerings | Where-Object { $_.Name -eq $name }
+        }
+
+        It 'Validate virtual network peering with <remoteVirtualNetwork.name> is connected' {
+            $remoteVirtualNetwork = Get-VirtualNetwork -Definition $Definition `
+                                                       -Contexts $Contexts `
+                                                       -Name $remoteVirtualNetwork.name `
+                                                       -SubscriptionId $remoteVirtualNetwork.subscriptionId `
+                                                       -ResourceGroupName $remoteVirtualNetwork.resourceGroupName 
+            
+            $peering | Should -Not -BeNullOrEmpty
+            $peering.RemoteVirtualNetwork.Id | Should -Be $remoteVirtualNetwork.Id
+            $peering.PeeringState | Should -Be "Connected"
+            $peering.ProvisioningState | Should -Be "Succeeded"
+        }
+        It 'Validate virtual network peering <propertyName> is <propertyValue>' -ForEach $properties {
+            $propertyName | Should -Not -BeNullOrEmpty
+            $propertyValue | Should -Not -BeNullOrEmpty
+            $peering.$propertyName | Should -Be $propertyValue
         }
     }
 }

--- a/Source/Schemas/2021-04/Network/schema.network.virtualnetworks.json
+++ b/Source/Schemas/2021-04/Network/schema.network.virtualnetworks.json
@@ -82,6 +82,22 @@
                     "type": "object",
                     "$ref": "#/definitions/routeTable",
                     "description": "(Optional) A `routeTable` object."
+                },
+                "privateEndpointNetworkPolicies": {
+                    "type": "string",
+                    "description": "(Optional) Enable or Disable apply network policies on private endpoint in the subnet.",
+                    "enum": [
+                        "Enabled",
+                        "Disabled"
+                    ]
+                },
+                "privateLinkServiceNetworkPolicies": {
+                    "type": "string",
+                    "description": "(Optional) Enable or Disable apply network policies on private link service in the subnet.",
+                    "enum": [
+                        "Enabled",
+                        "Disabled"
+                    ]
                 }
             },
             "additionalProperties": false
@@ -96,6 +112,22 @@
                 "name": {
                     "type": "string",
                     "description": "(Required) The virtual network peering name."
+                },
+                "allowVirtualNetworkAccess": {
+                    "type": "boolean",
+                    "description": "(Optional) Whether the VMs in the local virtual network space would be able to access the VMs in remote virtual network space."
+                },
+                "allowForwardedTraffic": {
+                    "type": "boolean",
+                    "description": "(Optional) Whether the forwarded traffic from the VMs in the local virtual network will be allowed/disallowed in remote virtual network."
+                },
+                "allowGatewayTransit": {
+                    "type": "boolean",
+                    "description": "(Optional) If gateway links can be used in remote virtual networking to link to this virtual network."
+                },
+                "useRemoteGateways": {
+                    "type": "boolean",
+                    "description": "(Optional) If remote gateways can be used on this virtual network."
                 },
                 "remoteVirtualNetwork": {
                     "type": "object",


### PR DESCRIPTION
Adding missing properties to subnet and virtualNetworkPeering objects

subnet : 
- privateEndpointNetworkPolicies
- privateLinkServiceNetworkPolicies

virtualNetworkPeering :
- allowVirtualNetworkAccess
- allowForwardedTraffic
- allowGatewayTransit
- useRemoteGateways