### PR TITLE
[feature] Adding test resources for key vault  

### DIFF
--- a/Docs/Resources/Security/KeyVault.md
+++ b/Docs/Resources/Security/KeyVault.md
@@ -1,0 +1,144 @@
+# Key Vault Documentation
+
+## Usage
+
+```json
+"definition": {
+    "security": {
+        "keyVaults": [
+            {
+                "name": "{parameters.keyVaultName}",
+                "location": "{parameters.location}",
+                "sku": "standard",
+                "enabledForDeployment": true,
+                "enabledForTemplateDeployment": true,
+                "enabledForDiskEncryption": true,
+                "enableSoftDelete": true,
+                "accessPolicies": [
+                    {
+                        "identity": {
+                            "name": "{parameters.principalName}",
+                            "type": "ServicePrincipal"
+                        },
+                        "permissions": {
+                            "secrets": [
+                                "get",
+                                "list",
+                                "set"
+                            ],
+                            "certificates": [
+                                "create",
+                                "get"
+                            ]
+                        }
+                    }
+                ],
+                "keys": [
+                    {
+                        "name": "{parameters.keyName}"
+                    }
+                ],
+                "secrets": [
+                    {
+                        "name": "{parameters.secretName}"
+                    }
+                ],
+                "certificates": [
+                    {
+                        "name": "{parameters.certificate.name}",
+                        "thumbprint": "{parameters.certificate.thumbprint}",
+                        "expirationThresholdInDays": 30
+                    }
+                ]
+            }
+        ]
+    }
+}
+```
+
+## Objects and Properties
+
+### keyVaults
+
+(Required) An array of `keyVault` objects.
+
+### keyVault object
+
+- `name`: (Required) The name of the key vault.
+  - Type: string
+- `location`: (Optional) The location where the key vault has been created.
+  - Type: string
+- `enabledForDeployment`: (Optional) Property to specify whether Azure Virtual Machines are permitted to retrieve certificates stored as secrets from the key vault.
+  - Type: boolean
+- `enabledForDiskEncryption`: (Optional) Property to specify whether Azure Disk Encryption is permitted to retrieve secrets from the vault and unwrap keys.
+  - Type: boolean
+- `enabledForTemplateDeployment`: (Optional) Property to specify whether Azure Resource Manager is permitted to retrieve secrets from the key vault.
+  - Type: boolean
+- `enablePurgeProtection`: (Optional) Property specifying whether protection against purge is enabled for this vault.
+  - Type: boolean
+- `enableRbacAuthorization`: (Optional) Property that controls how data actions are authorized. When true, the key vault will use Role Based Access Control (RBAC) for authorization of data actions, and the access policies specified in vault properties will be  ignored (warning: this is a preview feature).
+  - Type: boolean
+- `enableSoftDelete`: (Optional) Property to specify whether the 'soft delete' functionality is enabled for this key vault.
+  - Type: boolean
+- `sku`: (Optional) (Optional) SKU to specify whether the key vault is a standard vault or a premium vault.
+  - Type: string
+  - Valid Values: `standard` or `premium`.
+- `softDeleteRetentionInDays`: (Optional) softDelete data retention days.
+  - Type: integer
+- `accessPolicies`: (Optional) List of identities that have access to the key vault. Contains an array of `accessPolicy` objects.
+  - Type: accessPolicy[]
+- `keys`: (Optional) List of keys stored in the key vault. Contains an array of `key` objects.
+  - Type: key[]
+- `secrets`: (Optional) List of secrets stored in the key vault. Contains an array of `secret` objects.
+  - Type: secret[]
+- `certificates`: (Optional) List of certificates stored in the key vault. Contains an array of `certificate` objects.
+  - Type: certificate[]
+
+### accessPolicy object
+
+- `identity`: (Required) Identity definition that has access to the key vault. Contains an `identity` object.
+- Type: identity
+- `permissions`: (Required) List of permissions. Contains an array of `permission` objects.
+- Type: permission[]
+
+### identity object
+
+- `name`: (Required) The identity name.
+  - Type: string
+- `type`: (Required) The identity type.
+  - Type: string
+  - Valid Values: `ServicePrincipal`, `ManagedIdentity` and `Group`.
+
+### permission object
+
+- `keys`: (Optional) Permissions to keys. Array of strings.
+  - Type: string[]
+  - Valid Values: `all`, `encrypt`, `decrypt`, `wrapKey`, `unwrapKey`, `sign`, `verify`, `get`, `list`, `create`, `update`, `import`, `delete`, `backup`, `restore`, `recover`, `purge`
+- `secrets`: (Optional) Permissions to secrets. Array of strings.
+  - Type: string[]
+  - Valid Values: `all`, `get`, `list`, `set`, `delete`, `backup`, `restore`, `recover`, `purge`
+- `certificates`: (Optional) Permissions to certificates. Array of strings.
+  - Type: string[]
+  - Valid Values: `all`, `get`, `list`, `create`, `update`, `import`, `delete`, `managecontacts`, `getissuers`, `listissuers`, `setissuers`, `deleteissuers`, `manageissuers`, `backup`, `restore`, `recover`, `purge`
+- `storage`: (Optional) Permissions to storage. Array of strings.
+  - Type: string[]
+  - Valid Values: `all`, `get`, `list`, `delete`, `set`,`update`, `regeneratekey`, `recover`, `purge`, `backup`,`restore`, `setsas`, `listsas`, `getsas`, `deletesas`
+
+### key object
+
+- `name`: (Required) The name of the key.
+  - Type: string
+
+### secret object
+
+- `name`: (Required) The name of the secret.
+  - Type: string
+
+### certificate object
+
+- `name`: (Required) The name of the certificate.
+  - Type: string
+- `thumbprint`: (Optional) The thumbprint of the certificate.
+  - Type: string
+- `expirationThresholdInDays`: (Optional) The threshold in days before certificate expiration date.
+  - Type: integer

--- a/Source/Resources/Security/KeyVault/KeyVault.Tests.ps1
+++ b/Source/Resources/Security/KeyVault/KeyVault.Tests.ps1
@@ -1,0 +1,103 @@
+param (
+    [Parameter(Mandatory = $true)]
+    [PSObject] $Definition,
+    [Parameter(Mandatory = $true)]
+    [PSObject] $Contexts
+)
+
+BeforeDiscovery {
+    Import-Module -Force $PSScriptRoot/Parsers/Definition.psm1
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '')]
+    $KeyVaults = Find-KeyVaults -Definition $Definition
+}
+
+BeforeAll { 
+    . $PSScriptRoot/keyVault.ps1
+}
+
+Describe 'Key Vault <name> Acceptance Tests' -ForEach $KeyVaults {
+    BeforeAll {
+        [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '')]
+        $keyVault = Get-KeyVault -Definition $Definition -Contexts $Contexts -Name $name
+    }
+
+    Context 'Key Vault <name>'{
+        It 'Validate key vault <name> has been provisioned' {
+            $keyVault | Should -Not -BeNullOrEmpty
+        }
+        It 'Validate key vault <propertyName> is <propertyValue>' -ForEach $properties {
+            $propertyName | Should -Not -BeNullOrEmpty
+            $propertyValue | Should -Not -BeNullOrEmpty
+            $keyVault.$propertyName | Should -Be $propertyValue
+        }
+    }
+
+    Context 'Access Policies for <identity.name>' -ForEach $accessPolicies {
+        BeforeAll {
+            [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '')]
+            $objectId = Get-IdentityObjectId -Definition $Definition -Type $identity.type -Name $identity.name
+            [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '')]
+            $policy = $keyVault.AccessPolicies | Where-Object {$_.ObjectId -eq $objectId}
+        }
+
+        It 'Validate access policies for <identity.name> have been provisioned'{
+            $objectId | Should -Not -BeNullOrEmpty
+            $policy | Should -Not -BeNullOrEmpty
+        }
+        It 'Validate access policies <propertyName> is <propertyValue>' -ForEach $properties {
+            $propertyName | Should -Not -BeNullOrEmpty
+            $propertyValue | Should -Not -BeNullOrEmpty
+            ($policy.$propertyName | Sort-Object) | Should -Be ($propertyValue| Sort-Object)
+        }
+    }
+
+    Context 'Key <name>' -ForEach $keys {
+        BeforeAll {
+            [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '')]
+            $key = Get-KeyVaultKey -Definition $Definition -Contexts $Contexts -VaultName $keyVault.VaultName -Name $name
+        }
+
+        It 'Validate key is Enabled' {
+            $key | Should -Not -BeNullOrEmpty
+            $key.Name | Should -Be $name
+            $key.Enabled | Should -BeTrue
+        }
+    }
+
+    Context 'Secret <name>' -ForEach $secrets {
+        BeforeAll {
+            [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '')]
+            $secret = Get-KeyVaultSecret -Definition $Definition -Contexts $Contexts -VaultName $keyVault.VaultName -Name $name
+        }
+
+        It 'Validate secret is Enabled'  {
+            $secret | Should -Not -BeNullOrEmpty
+            $secret.Name | Should -Be $name
+            $secret.Enabled | Should -BeTrue
+        }
+    }
+
+    Context 'Certificate <name>' -ForEach $certificates {
+        BeforeAll {
+            [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '')]
+            $certificate = Get-KeyVaultCertificate -Definition $Definition -Contexts $Contexts -VaultName $keyVault.VaultName -Name $name
+        }
+
+        It 'Validate certificate is Enabled'  {
+            $certificate | Should -Not -BeNullOrEmpty
+            $certificate.Name | Should -Be $name
+            $certificate.Enabled | Should -BeTrue
+        }
+        It 'Validate certificate <propertyName> is <displayValue>' -ForEach $properties {
+            if($propertyName -eq 'expiration') {
+                $certificate.Expires | Should -BeGreaterThan (Get-Date).AddDays($propertyValue)
+            }
+            else {
+                $propertyName | Should -Not -BeNullOrEmpty
+                $propertyValue | Should -Not -BeNullOrEmpty
+                $certificate.$propertyName | Should -Be $propertyValue
+            }
+        }
+    }
+}
+

--- a/Source/Resources/Security/KeyVault/KeyVault.ps1
+++ b/Source/Resources/Security/KeyVault/KeyVault.ps1
@@ -1,0 +1,182 @@
+class IdentityTypes {
+    static [string] $ServicePrincipal = 'ServicePrincipal'
+    static [string] $ManagedIdentity = 'ManagedIdentity'
+    static [string] $Group = 'Group'
+}
+
+function Get-IdentityTypes {
+    return [IdentityTypes]::new()
+}
+
+function Get-IdentityObjectId {
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNull()]
+        [PSObject] $Definition,
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [String] $Type,
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [String] $Name
+    )
+
+    $resourceGroupName = $Contexts.default.resourceGroupName
+    if ([string]::IsNullOrWhiteSpace($resourceGroupName)) {
+        throw 'The default resourceGroupName input value is Null|Empty or WhiteSpace.'
+    }
+
+    if($Type -eq (Get-IdentityTypes)::ServicePrincipal) {
+        $identity = Get-AzADServicePrincipal -DisplayName $name
+        return $identity.Id
+    }
+    elseif($Type -eq (Get-IdentityTypes)::ManagedIdentity) {
+        $identity = Get-AzUserAssignedIdentity -ResourceGroupName $resourceGroupName -Name $Name
+        return $identity.PrincipalId
+    }
+    elseif($Type -eq (Get-IdentityTypes)::Group) {
+        $identity = Get-AzADGroup -DisplayName $name
+        return $identity.Id
+    }
+    else {
+        Write-Host "Issue: Type $Type used by Get-IdentityObjectId is not supported." -ForegroundColor Red
+    }
+}
+
+function Get-KeyVault {
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNull()]
+        [PSObject] $Definition,
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNull()]
+        [PSObject] $Contexts,
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [String] $Name,
+        [Parameter(Mandatory = $false)]
+        [String] $SubscriptionId,
+        [Parameter(Mandatory = $false)]
+        [String] $ResourceGroupName
+    )
+
+    if(!$ResourceGroupName) {
+        $ResourceGroupName = $Contexts.default.resourceGroupName
+        if ([string]::IsNullOrWhiteSpace($ResourceGroupName)) {
+            throw 'The default resourceGroupName input value is Null|Empty or WhiteSpace.'
+        }
+    }
+
+    if($SubscriptionId) {
+        ForEach ($context in $Contexts.GetEnumerator()) {
+            if ($context.Value.SubscriptionId -eq $SubscriptionId) {
+                # Get virtual network
+                $keyVault = Get-AzKeyVault -ResourceGroupName $ResourceGroupName -VaultName $Name -DefaultProfile $context.Value.Context
+                return $keyVault 
+            }
+        }
+
+        Write-Host "Warning: Subscription $SubscriptionId is unknown. This subscription should be referenced in contexts." -ForegroundColor Yellow
+    }
+    
+    Get-AzKeyVault -ResourceGroupName $ResourceGroupName -VaultName $Name
+}
+
+function Get-KeyVaultSecret {
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNull()]
+        [PSObject] $Definition,
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNull()]
+        [PSObject] $Contexts,
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [String] $VaultName,
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [String] $Name,
+        [Parameter(Mandatory = $false)]
+        [String] $SubscriptionId
+    )
+
+    if($SubscriptionId) {
+        ForEach ($context in $Contexts.GetEnumerator()) {
+            if ($context.Value.SubscriptionId -eq $SubscriptionId) {
+                # Get secret
+                $secret = Get-AzKeyVaultSecret -VaultName $VaultName -Name $Name -DefaultProfile $context.Value.Context
+                return $secret 
+            }
+        }
+
+        Write-Host "Warning: Subscription $SubscriptionId is unknown. This subscription should be referenced in contexts." -ForegroundColor Yellow
+    }
+    
+    Get-AzKeyVaultSecret -VaultName $VaultName -Name $Name
+}
+
+function Get-KeyVaultKey {
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNull()]
+        [PSObject] $Definition,
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNull()]
+        [PSObject] $Contexts,
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [String] $VaultName,
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [String] $Name,
+        [Parameter(Mandatory = $false)]
+        [String] $SubscriptionId
+    )
+
+    if($SubscriptionId) {
+        ForEach ($context in $Contexts.GetEnumerator()) {
+            if ($context.Value.SubscriptionId -eq $SubscriptionId) {
+                # Get key
+                $key = Get-AzKeyVaultKey -VaultName $VaultName -Name $Name -DefaultProfile $context.Value.Context
+                return $key 
+            }
+        }
+
+        Write-Host "Warning: Subscription $SubscriptionId is unknown. This subscription should be referenced in contexts." -ForegroundColor Yellow
+    }
+    
+    Get-AzKeyVaultKey  -VaultName $VaultName -Name $Name
+}
+
+function Get-KeyVaultCertificate {
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNull()]
+        [PSObject] $Definition,
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNull()]
+        [PSObject] $Contexts,
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [String] $VaultName,
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [String] $Name,
+        [Parameter(Mandatory = $false)]
+        [String] $SubscriptionId
+    )
+
+    if($SubscriptionId) {
+        ForEach ($context in $Contexts.GetEnumerator()) {
+            if ($context.Value.SubscriptionId -eq $SubscriptionId) {
+                # Get certificate
+                $certificate = Get-AzKeyVaultCertificate -VaultName $VaultName -Name $Name -DefaultProfile $context.Value.Context
+                return $certificate 
+            }
+        }
+
+        Write-Host "Warning: Subscription $SubscriptionId is unknown. This subscription should be referenced in contexts." -ForegroundColor Yellow
+    }
+    
+    Get-AzKeyVaultCertificate  -VaultName $VaultName -Name $Name
+}

--- a/Source/Resources/Security/KeyVault/Parsers/Definition.psm1
+++ b/Source/Resources/Security/KeyVault/Parsers/Definition.psm1
@@ -1,0 +1,102 @@
+function Find-KeyVaults {
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNull()]
+        [PSObject] $Definition
+    )
+
+    $keyVaults = $Definition.security.keyVaults
+
+    foreach ($keyVault in $keyVaults) {
+        $properties = @()
+
+        if ($null -ne $keyVault.location) {
+            $properties += Add-Property -PropertyName 'location' -PropertyValue $keyVault.location
+        }
+        if ($null -ne $keyVault.sku) {
+            $properties += Add-Property -PropertyName 'sku' -PropertyValue $keyVault.sku
+        }
+        if ($null -ne $keyVault.enabledForDeployment) {
+            $properties += Add-Property -PropertyName 'enabledForDeployment' -PropertyValue $keyVault.enabledForDeployment
+        }
+        if ($null -ne $keyVault.enabledForTemplateDeployment) {
+            $properties += Add-Property -PropertyName 'enabledForTemplateDeployment' -PropertyValue $keyVault.enabledForTemplateDeployment
+        }
+        if ($null -ne $keyVault.enabledForDiskEncryption) {
+            $properties += Add-Property -PropertyName 'enabledForDiskEncryption' -PropertyValue $keyVault.enabledForDiskEncryption
+        }
+        if ($null -ne $keyVault.enablePurgeProtection) {
+            $properties += Add-Property -PropertyName 'enablePurgeProtection' -PropertyValue $keyVault.enablePurgeProtection
+        }
+        if ($null -ne $keyVault.enableRbacAuthorization) {
+            $properties += Add-Property -PropertyName 'enableRbacAuthorization' -PropertyValue $keyVault.enableRbacAuthorization
+        }
+        if ($null -ne $keyVault.enableSoftDelete) {
+            $properties += Add-Property -PropertyName 'enableSoftDelete' -PropertyValue $keyVault.enableSoftDelete
+        }
+        if ($null -ne $keyVault.softDeleteRetentionInDays) {
+            $properties += Add-Property -PropertyName 'softDeleteRetentionInDays' -PropertyValue $keyVault.softDeleteRetentionInDays
+        }
+
+        if ($keyVault.accessPolicies) {
+            foreach ($policy in $keyVault.accessPolicies) {
+                $policyProperties = @()
+
+                if ($null -ne ${policy}?.permissions['keys']) {
+                    $policyProperties += Add-Property -PropertyName 'permissionsToKeys' -PropertyValue $policy.permissions['keys']
+                }
+                if ($null -ne ${policy}?.permissions['secrets']) {
+                    $policyProperties += Add-Property -PropertyName 'permissionsToSecrets' -PropertyValue $policy.permissions['secrets']
+                }
+                if ($null -ne ${policy}?.permissions['certificates']) {
+                    $policyProperties += Add-Property -PropertyName 'permissionsToCertificates' -PropertyValue $policy.permissions['certificates']
+                }
+                if ($null -ne ${policy}?.permissions['storage']) {
+                    $policyProperties += Add-Property -PropertyName 'permissionsToStorage' -PropertyValue $policy.permissions['storage']
+                }
+
+                $policy.properties = $policyProperties
+            }
+        }
+
+        if ($keyVault.certificates) {
+            foreach ($certificate in $keyVault.certificates) {
+                $certificateProperties = @()
+
+                if ($null -ne $certificate.thumbprint) {
+                    $certificateProperties += Add-Property -PropertyName 'thumbprint' -PropertyValue $certificate.thumbprint
+                }
+                if ($null -ne $certificate.expirationThresholdInDays) {
+                    $certificateProperties += Add-Property -PropertyName 'expiration' -PropertyValue $certificate.expirationThresholdInDays -DisplayValue "greater than $($certificate.expirationThresholdInDays) days"
+                }
+
+                $certificate.properties = $certificateProperties
+            }
+        }
+
+        $keyVault.properties = $properties
+    }
+
+    return $keyVaults
+}
+
+function Add-Property {
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNull()]
+        [string] $PropertyName,
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNull()]
+        [PSObject] $PropertyValue,
+        [Parameter(Mandatory = $false)]
+        [PSObject] $DisplayValue
+    )
+
+    if (!$DisplayValue) {
+        $DisplayValue = $PropertyValue
+    }
+
+    return @{propertyName = $PropertyName; propertyValue = $PropertyValue; displayValue = $DisplayValue }
+}
+
+Export-ModuleMember -Function Find-KeyVaults

--- a/Source/Schemas/2021-04/Security/schema.security.json
+++ b/Source/Schemas/2021-04/Security/schema.security.json
@@ -1,0 +1,20 @@
+{
+    "id": "schema.security",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "Security",
+    "description": "Schema for Security Section",
+    "definitions": {
+        "network": {
+            "type": "object",
+            "properties": {
+                "keyVaults": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "schema.network.keyvaults.json#/definitions/keyVault"
+                    }
+                }
+            },
+            "additionalProperties": false
+        }
+    }
+}

--- a/Source/Schemas/2021-04/Security/schema.security.json
+++ b/Source/Schemas/2021-04/Security/schema.security.json
@@ -4,13 +4,13 @@
     "title": "Security",
     "description": "Schema for Security Section",
     "definitions": {
-        "network": {
+        "security": {
             "type": "object",
             "properties": {
                 "keyVaults": {
                     "type": "array",
                     "items": {
-                        "$ref": "schema.network.keyvaults.json#/definitions/keyVault"
+                        "$ref": "schema.security.keyvaults.json#/definitions/keyVault"
                     }
                 }
             },

--- a/Source/Schemas/2021-04/Security/schema.security.keyvaults.json
+++ b/Source/Schemas/2021-04/Security/schema.security.keyvaults.json
@@ -32,7 +32,7 @@
                 },
                 "enablePurgeProtection": {
                     "type": "boolean",
-                    "description": "(Optional) Property specifying whether protection against purge is enabled for this vault. Setting this property to true activates protection against purge for this vault and its content - only the Key Vault service may initiate a hard, irrecoverable deletion. The setting is effective only if soft delete is also enabled. Enabling this functionality is irreversible - that is, the property does not accept false as its value."
+                    "description": "(Optional) Property specifying whether protection against purge is enabled for this vault."
                 },
                 "enableRbacAuthorization": {
                     "type": "boolean",
@@ -57,113 +57,146 @@
                 "accessPolicies": {
                     "type": "array",
                     "items": {
-                        "href": "#/definitions/accessPolicy"
+                        "$ref": "#/definitions/accessPolicy"
                     },
-                    "description": "An array of identities that have access to the key vault."
-                }
-            }
-        },
-        "accessPolicy" : {
-            "identity": {
-               "$ref": "#/definitions/identity"
-            },
-            "permissions" : {
-                "type": "object",
+                    "description": "(Optional) An array of identities that have access to the key vault."
+                },
                 "keys": {
                     "type": "array",
                     "items": {
-                        "type": "string",
-                        "enum": [
-                            "all",
-                            "encrypt",
-                            "decrypt",
-                            "wrapKey",
-                            "unwrapKey",
-                            "sign",
-                            "verify",
-                            "get",
-                            "list",
-                            "create",
-                            "update",
-                            "import",
-                            "delete",
-                            "backup",
-                            "restore",
-                            "recover",
-                            "purge"
-                        ]
+                        "$ref": "#/definitions/key"
                     },
-                    "description": "Permissions to keys"
+                    "description": "(Optional) List of keys stored in the key vault."
                 },
                 "secrets": {
                     "type": "array",
                     "items": {
-                        "type": "string",
-                        "enum": [
-                            "all",
-                            "get",
-                            "list",
-                            "set",
-                            "delete",
-                            "backup",
-                            "restore",
-                            "recover",
-                            "purge"
-                        ]
+                        "$ref": "#/definitions/secret"
                     },
-                    "description": "Permissions to secrets"
+                    "description": "(Optional) List of secrets stored in the key vault."
                 },
                 "certificates": {
                     "type": "array",
                     "items": {
-                        "type": "string",
-                        "enum": [
-                            "all",
-                            "get",
-                            "list",
-                            "delete",
-                            "create",
-                            "import",
-                            "update",
-                            "managecontacts",
-                            "getissuers",
-                            "listissuers",
-                            "setissuers",
-                            "deleteissuers",
-                            "manageissuers",
-                            "recover",
-                            "purge",
-                            "backup",
-                            "restore"
-                        ]
+                        "$ref": "#/definitions/certificate"
                     },
-                    "description": "Permissions to certificates"
-                },
-                "storage": {
-                    "type": "array",
-                    "items": {
-                        "type": "string",
-                        "enum": [
-                            "all",
-                            "get",
-                            "list",
-                            "delete",
-                            "set",
-                            "update",
-                            "regeneratekey",
-                            "recover",
-                            "purge",
-                            "backup",
-                            "restore",
-                            "setsas",
-                            "listsas",
-                            "getsas",
-                            "deletesas"
-                        ]
-                    },
-                    "description": "Permissions to storage"
+                    "description": "(Optional) List of certificates stored in the key vault."
                 }
-            }
+            },
+            "additionalProperties": false
+        },
+        "accessPolicy": {
+            "type": "object",
+            "required": [
+                "identity",
+                "permissions"
+            ],
+            "properties": {
+                "identity": {
+                    "$ref": "#/definitions/identity"
+                },
+                "permissions": {
+                    "type": "object",
+                    "properties": {
+                        "keys": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "enum": [
+                                    "all",
+                                    "encrypt",
+                                    "decrypt",
+                                    "wrapKey",
+                                    "unwrapKey",
+                                    "sign",
+                                    "verify",
+                                    "get",
+                                    "list",
+                                    "create",
+                                    "update",
+                                    "import",
+                                    "delete",
+                                    "backup",
+                                    "restore",
+                                    "recover",
+                                    "purge"
+                                ]
+                            },
+                            "description": "(Optional) Permissions to keys"
+                        },
+                        "secrets": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "enum": [
+                                    "all",
+                                    "get",
+                                    "list",
+                                    "set",
+                                    "delete",
+                                    "backup",
+                                    "restore",
+                                    "recover",
+                                    "purge"
+                                ]
+                            },
+                            "description": "(Optional) Permissions to secrets"
+                        },
+                        "certificates": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "enum": [
+                                    "all",
+                                    "get",
+                                    "list",
+                                    "delete",
+                                    "create",
+                                    "import",
+                                    "update",
+                                    "managecontacts",
+                                    "getissuers",
+                                    "listissuers",
+                                    "setissuers",
+                                    "deleteissuers",
+                                    "manageissuers",
+                                    "recover",
+                                    "purge",
+                                    "backup",
+                                    "restore"
+                                ]
+                            },
+                            "description": "(Optional) Permissions to certificates"
+                        },
+                        "storage": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "enum": [
+                                    "all",
+                                    "get",
+                                    "list",
+                                    "delete",
+                                    "set",
+                                    "update",
+                                    "regeneratekey",
+                                    "recover",
+                                    "purge",
+                                    "backup",
+                                    "restore",
+                                    "setsas",
+                                    "listsas",
+                                    "getsas",
+                                    "deletesas"
+                                ]
+                            },
+                            "description": "(Optional) Permissions to storage"
+                        }
+                    },
+                    "additionalProperties": false
+                }
+            },
+            "additionalProperties": false
         },
         "identity": {
             "type": "object",
@@ -185,7 +218,56 @@
                         "Group"
                     ]
                 }
-            }
+            },
+            "description": "(Required) Identity definition that has access to the key vault.",
+            "additionalProperties": false
+        },
+        "key": {
+            "type": "object",
+            "required": [
+                "name"
+            ],
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "(Required) The name of the key"
+                }
+            },
+            "additionalProperties": false
+        },
+        "secret": {
+            "type": "object",
+            "required": [
+                "name"
+            ],
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "(Required) The name of the secret"
+                }
+            },
+            "additionalProperties": false
+        },
+        "certificate": {
+            "type": "object",
+            "required": [
+                "name"
+            ],
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "(Required) The name of the certificate."
+                },
+                "thumbprint": {
+                    "type": "string",
+                    "description": "(Optional) The thumbprint of the certificate."
+                },
+                "expirationThresholdInDays": {
+                    "type": "integer",
+                    "description": "(Optional) The threshold in days before certificate expiration date."
+                }
+            },
+            "additionalProperties": false
         }
     }
 }

--- a/Source/Schemas/2021-04/Security/schema.security.keyvaults.json
+++ b/Source/Schemas/2021-04/Security/schema.security.keyvaults.json
@@ -1,0 +1,191 @@
+{
+    "id": "schema.security.keyvaults",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "Key Vault",
+    "description": "Schema for Key Vault Section",
+    "definitions": {
+        "keyVault": {
+            "type": "object",
+            "required": [
+                "name"
+            ],
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "(Required) The name of the key vault."
+                },
+                "location": {
+                    "type": "string",
+                    "description": "(Optional) The location where the key vault has been created."
+                },
+                "enabledForDeployment": {
+                    "type": "boolean",
+                    "description": "(Optional) Property to specify whether Azure Virtual Machines are permitted to retrieve certificates stored as secrets from the key vault."
+                },
+                "enabledForDiskEncryption": {
+                    "type": "boolean",
+                    "description": "(Optional) Property to specify whether Azure Disk Encryption is permitted to retrieve secrets from the vault and unwrap keys."
+                },
+                "enabledForTemplateDeployment": {
+                    "type": "boolean",
+                    "description": "(Optional) Property to specify whether Azure Resource Manager is permitted to retrieve secrets from the key vault."
+                },
+                "enablePurgeProtection": {
+                    "type": "boolean",
+                    "description": "(Optional) Property specifying whether protection against purge is enabled for this vault. Setting this property to true activates protection against purge for this vault and its content - only the Key Vault service may initiate a hard, irrecoverable deletion. The setting is effective only if soft delete is also enabled. Enabling this functionality is irreversible - that is, the property does not accept false as its value."
+                },
+                "enableRbacAuthorization": {
+                    "type": "boolean",
+                    "description": "(Optional) Property that controls how data actions are authorized. When true, the key vault will use Role Based Access Control (RBAC) for authorization of data actions, and the access policies specified in vault properties will be  ignored (warning: this is a preview feature). When false, the key vault will use the access policies specified in vault properties, and any policy stored on Azure Resource Manager will be ignored. If null or not specified, the vault is created with the default value of false. Note that management actions are always authorized with RBAC."
+                },
+                "enableSoftDelete": {
+                    "type": "boolean",
+                    "description": "(Optional) Property to specify whether the 'soft delete' functionality is enabled for this key vault. If it's not set to any value(true or false) when creating new key vault, it will be set to true by default. Once set to true, it cannot be reverted to false."
+                },
+                "sku": {
+                    "type": "string",
+                    "enum": [
+                        "standard",
+                        "premium"
+                    ],
+                    "description": "(Optional) SKU to specify whether the key vault is a standard vault or a premium vault."
+                },
+                "softDeleteRetentionInDays": {
+                    "type": "integer",
+                    "description": "(Optional) softDelete data retention days. It accepts >=7 and <=90."
+                },
+                "accessPolicies": {
+                    "type": "array",
+                    "items": {
+                        "href": "#/definitions/accessPolicy"
+                    },
+                    "description": "An array of identities that have access to the key vault."
+                }
+            }
+        },
+        "accessPolicy" : {
+            "identity": {
+               "$ref": "#/definitions/identity"
+            },
+            "permissions" : {
+                "type": "object",
+                "keys": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "enum": [
+                            "all",
+                            "encrypt",
+                            "decrypt",
+                            "wrapKey",
+                            "unwrapKey",
+                            "sign",
+                            "verify",
+                            "get",
+                            "list",
+                            "create",
+                            "update",
+                            "import",
+                            "delete",
+                            "backup",
+                            "restore",
+                            "recover",
+                            "purge"
+                        ]
+                    },
+                    "description": "Permissions to keys"
+                },
+                "secrets": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "enum": [
+                            "all",
+                            "get",
+                            "list",
+                            "set",
+                            "delete",
+                            "backup",
+                            "restore",
+                            "recover",
+                            "purge"
+                        ]
+                    },
+                    "description": "Permissions to secrets"
+                },
+                "certificates": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "enum": [
+                            "all",
+                            "get",
+                            "list",
+                            "delete",
+                            "create",
+                            "import",
+                            "update",
+                            "managecontacts",
+                            "getissuers",
+                            "listissuers",
+                            "setissuers",
+                            "deleteissuers",
+                            "manageissuers",
+                            "recover",
+                            "purge",
+                            "backup",
+                            "restore"
+                        ]
+                    },
+                    "description": "Permissions to certificates"
+                },
+                "storage": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "enum": [
+                            "all",
+                            "get",
+                            "list",
+                            "delete",
+                            "set",
+                            "update",
+                            "regeneratekey",
+                            "recover",
+                            "purge",
+                            "backup",
+                            "restore",
+                            "setsas",
+                            "listsas",
+                            "getsas",
+                            "deletesas"
+                        ]
+                    },
+                    "description": "Permissions to storage"
+                }
+            }
+        },
+        "identity": {
+            "type": "object",
+            "required": [
+                "name",
+                "type"
+            ],
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "(Required) The identity name."
+                },
+                "type": {
+                    "type": "string",
+                    "description": "(Required) The identity type.",
+                    "enum": [
+                        "ManagedIdentity",
+                        "ServicePrincipal",
+                        "Group"
+                    ]
+                }
+            }
+        }
+    }
+}

--- a/Source/Schemas/2021-04/schema.definition.json
+++ b/Source/Schemas/2021-04/schema.definition.json
@@ -55,6 +55,9 @@
                 },
                 "identity": {
                     "$ref": "./Identity/schema.identity.json#/definitions/identity"
+                },
+                "security": {
+                    "$ref": "./Security/schema.security.json#/definitions/security"
                 }
             },
             "additionalProperties": false


### PR DESCRIPTION
## Adding test resources for key vault  (close #5)

- [x] json schema
- [x] test resources
- [x] documentation
- [ ] sample

Sample postponed, hub-spoke sample doesn't provide any key vault. Need to target another architecture.

### Usage 

```json
"definition": {
    "security": {
        "keyVaults": [
            {
                "name": "{parameters.keyVaultName}",
                "location": "{parameters.location}",
                "sku": "standard",
                "enabledForDeployment": true,
                "enabledForTemplateDeployment": true,
                "enabledForDiskEncryption": true,
                "enableSoftDelete": true,
                "accessPolicies": [
                    {
                        "identity": {
                            "name": "{parameters.principalName}",
                            "type": "ServicePrincipal"
                        },
                        "permissions": {
                            "secrets": [
                                "get",
                                "list",
                                "set"
                            ],
                            "certificates": [
                                "create",
                                "get"
                            ]
                        }
                    }
                ],
                "keys": [
                    {
                        "name": "{parameters.keyName}"
                    }
                ],
                "secrets": [
                    {
                        "name": "{parameters.secretName}"
                    }
                ],
                "certificates": [
                    {
                        "name": "{parameters.certificate.name}",
                        "thumbprint": "{parameters.certificate.thumbprint}",
                        "expirationThresholdInDays": 30
                    }
                ]
            }
        ]
    }
}
```

### Output

``` Powershell
Describing Key Vault kv-jsjc01 Acceptance Tests
 Context Key Vault kv-jsjc01
   [+] Validate key vault kv-jsjc01 has been provisioned 16ms (5ms|11ms)
   [+] Validate key vault location is northeurope 9ms (7ms|2ms)
   [+] Validate key vault sku is standard 6ms (5ms|1ms)
   [+] Validate key vault enabledForDeployment is True 16ms (15ms|1ms)
   [+] Validate key vault enabledForTemplateDeployment is True 5ms (3ms|2ms)
   [+] Validate key vault enabledForDiskEncryption is True 5ms (4ms|1ms)
   [+] Validate key vault enableSoftDelete is True 7ms (6ms|1ms)
 Context Access Policies for IT-SP-02
   [+] Validate access policies for IT-SP-02 have been provisioned 18ms (3ms|15ms)
   [+] Validate access policies permissionsToSecrets is get list set 8ms (7ms|1ms)
   [+] Validate access policies permissionsToCertificates is create get 16ms (4ms|13ms)
 Context Key testkey
   [+] Validate key is Enabled 7ms (3ms|4ms)
 Context Secret testsecret
   [+] Validate secret is Enabled 24ms (3ms|21ms)
 Context Certificate testcertificate
   [+] Validate certificate is Enabled 7ms (2ms|5ms)
   [+] Validate certificate thumbprint is E16B5748DA14BB7730209C88040D1547296246DB 4ms (3ms|1ms)
   [+] Validate certificate expiration is greater than 30 days 15ms (7ms|8ms)
Tests completed in 8.93s
Tests Passed: 15, Failed: 0, Skipped: 0 NotRun: 0
```
